### PR TITLE
Adds exclude by value strategies

### DIFF
--- a/src/main/java/io/gsonfire/annotations/ExcludeByValue.java
+++ b/src/main/java/io/gsonfire/annotations/ExcludeByValue.java
@@ -1,0 +1,14 @@
+package io.gsonfire.annotations;
+
+import io.gsonfire.gson.ExclusionByValueStrategy;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ExcludeByValue {
+    Class<? extends ExclusionByValueStrategy> value();
+}

--- a/src/main/java/io/gsonfire/gson/ExclusionByValueStrategy.java
+++ b/src/main/java/io/gsonfire/gson/ExclusionByValueStrategy.java
@@ -1,0 +1,7 @@
+package io.gsonfire.gson;
+
+public interface ExclusionByValueStrategy<T> {
+
+    boolean	shouldSkipField(T fieldValue);
+
+}

--- a/src/main/java/io/gsonfire/gson/ExclusionByValueStrategy.java
+++ b/src/main/java/io/gsonfire/gson/ExclusionByValueStrategy.java
@@ -2,6 +2,6 @@ package io.gsonfire.gson;
 
 public interface ExclusionByValueStrategy<T> {
 
-    boolean	shouldSkipField(T fieldValue);
+    boolean shouldSkipField(T fieldValue);
 
 }

--- a/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
+++ b/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
@@ -1,8 +1,6 @@
 package io.gsonfire.postprocessors;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
+import com.google.gson.*;
 import com.google.gson.annotations.SerializedName;
 import io.gsonfire.PostProcessor;
 import io.gsonfire.annotations.ExcludeByValue;
@@ -51,6 +49,6 @@ public final class ExclusionByValuePostProcessor implements PostProcessor {
 
     private String getFieldName(Field f) {
         SerializedName serializedName = f.getAnnotation(SerializedName.class);
-        return serializedName == null ? f.getName() : serializedName.value();
+        return serializedName == null ? FieldNamingPolicy.IDENTITY.translateName(f) : serializedName.value();
     }
 }

--- a/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
+++ b/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
@@ -58,6 +58,15 @@ public final class ExclusionByValuePostProcessor implements PostProcessor {
         }
     }
 
+    /**
+     * Will try to resolve the name of the field in the {@link JsonObject} using different strategies. First it will
+     * look into the {@link SerializedName} annotation, if it cannot find it, it will try all naming policies. Once a
+     * match has been found, the naming policy will be cached (it is assumed Gson has only one policy). A cache is
+     * maintained also for all missing fields to avoid trying to resolve them again.
+     * @param f
+     * @param json
+     * @return
+     */
     private String resolveFieldName(Field f, JsonObject json) {
 
         if(this.fieldNameCache.containsKey(f)) {

--- a/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
+++ b/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
@@ -26,7 +26,7 @@ public final class ExclusionByValuePostProcessor implements PostProcessor {
 
     @Override
     public void postSerialize(JsonElement result, Object src, Gson gson) {
-        if(src == null){
+        if(src == null || result.isJsonNull() || !result.isJsonObject()){
             return;
         }
         for(Field f: fieldInspector.getAnnotatedFields(src.getClass(), ExcludeByValue.class)){

--- a/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
+++ b/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
@@ -1,0 +1,56 @@
+package io.gsonfire.postprocessors;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
+import io.gsonfire.PostProcessor;
+import io.gsonfire.annotations.ExcludeByValue;
+import io.gsonfire.gson.ExclusionByValueStrategy;
+import io.gsonfire.util.FieldInspector;
+
+import java.lang.reflect.Field;
+
+public final class ExclusionByValuePostProcessor implements PostProcessor {
+
+    private FieldInspector fieldInspector;
+
+    public ExclusionByValuePostProcessor(FieldInspector fieldInspector) {
+        this.fieldInspector = fieldInspector;
+    }
+
+    @Override
+    public void postDeserialize(Object result, JsonElement src, Gson gson) {
+        //nothing
+    }
+
+    @Override
+    public void postSerialize(JsonElement result, Object src, Gson gson) {
+        if(src == null){
+            return;
+        }
+        for(Field f: fieldInspector.getAnnotatedFields(src.getClass(), ExcludeByValue.class)){
+            try {
+                ExcludeByValue excludeByValue = f.getAnnotation(ExcludeByValue.class);
+                Class<? extends ExclusionByValueStrategy> exclusionByValueStrategyClass = excludeByValue.value();
+
+                ExclusionByValueStrategy strategy = exclusionByValueStrategyClass.newInstance();
+                if (strategy.shouldSkipField(f.get(src))) {
+                    JsonObject resultJsonObject = result.getAsJsonObject();
+                    resultJsonObject.remove(getFieldName(f));
+                } else {
+                    // continue
+                }
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            } catch (InstantiationException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private String getFieldName(Field f) {
+        SerializedName serializedName = f.getAnnotation(SerializedName.class);
+        return serializedName == null ? f.getName() : serializedName.value();
+    }
+}

--- a/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
+++ b/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
@@ -11,7 +11,7 @@ import java.lang.reflect.Field;
 
 public final class ExclusionByValuePostProcessor implements PostProcessor {
 
-    private FieldInspector fieldInspector;
+    private final FieldInspector fieldInspector;
 
     public ExclusionByValuePostProcessor(FieldInspector fieldInspector) {
         this.fieldInspector = fieldInspector;

--- a/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
+++ b/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
@@ -1,6 +1,9 @@
 package io.gsonfire.postprocessors;
 
-import com.google.gson.*;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import io.gsonfire.PostProcessor;
 import io.gsonfire.annotations.ExcludeByValue;
@@ -8,10 +11,13 @@ import io.gsonfire.gson.ExclusionByValueStrategy;
 import io.gsonfire.util.FieldInspector;
 
 import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
 
 public final class ExclusionByValuePostProcessor implements PostProcessor {
 
     private final FieldInspector fieldInspector;
+    private final Map<Field, String> fieldNameCache = new HashMap<Field,String>();
 
     private FieldNamingPolicy fieldNamingPolicy = null;
 
@@ -53,6 +59,11 @@ public final class ExclusionByValuePostProcessor implements PostProcessor {
     }
 
     private String resolveFieldName(Field f, JsonObject json) {
+
+        if(this.fieldNameCache.containsKey(f)) {
+            return this.fieldNameCache.get(f);
+        }
+
         SerializedName serializedName = f.getAnnotation(SerializedName.class);
         if(serializedName != null) {
             return serializedName.value();
@@ -60,6 +71,7 @@ public final class ExclusionByValuePostProcessor implements PostProcessor {
             //Check if the field exists with the cached fieldNamingPolicy
             String fieldName = fieldNamingPolicy.translateName(f);
             if(json.has(fieldName)) {
+                this.fieldNameCache.put(f, fieldName);
                 return fieldName;
             }
         }
@@ -71,6 +83,7 @@ public final class ExclusionByValuePostProcessor implements PostProcessor {
                 if(fieldNamingPolicy == null) {
                     fieldNamingPolicy = candidatePolicy;
                 }
+                this.fieldNameCache.put(f, fieldName);
                 return fieldName;
             }
         }

--- a/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
+++ b/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
@@ -63,36 +63,36 @@ public final class ExclusionByValuePostProcessor implements PostProcessor {
      * look into the {@link SerializedName} annotation, if it cannot find it, it will try all naming policies. Once a
      * match has been found, the naming policy will be cached (it is assumed Gson has only one policy). A cache is
      * maintained also for all missing fields to avoid trying to resolve them again.
-     * @param f
+     * @param field
      * @param json
      * @return
      */
-    private String resolveFieldName(Field f, JsonObject json) {
+    private String resolveFieldName(Field field, JsonObject json) {
 
-        if(this.fieldNameCache.containsKey(f)) {
-            return this.fieldNameCache.get(f);
+        if(this.fieldNameCache.containsKey(field)) {
+            return this.fieldNameCache.get(field);
         }
 
-        SerializedName serializedName = f.getAnnotation(SerializedName.class);
+        SerializedName serializedName = field.getAnnotation(SerializedName.class);
         if(serializedName != null) {
             return serializedName.value();
         } else if (fieldNamingPolicy != null) {
             //Check if the field exists with the cached fieldNamingPolicy
-            String fieldName = fieldNamingPolicy.translateName(f);
+            String fieldName = fieldNamingPolicy.translateName(field);
             if(json.has(fieldName)) {
-                this.fieldNameCache.put(f, fieldName);
+                this.fieldNameCache.put(field, fieldName);
                 return fieldName;
             }
         }
 
         //There has been no match, lets brute force and try to find the field name
         for(FieldNamingPolicy candidatePolicy: FieldNamingPolicy.values()) {
-            String fieldName = candidatePolicy.translateName(f);
+            String fieldName = candidatePolicy.translateName(field);
             if(json.has(fieldName)) {
                 if(fieldNamingPolicy == null) {
                     fieldNamingPolicy = candidatePolicy;
                 }
-                this.fieldNameCache.put(f, fieldName);
+                this.fieldNameCache.put(field, fieldName);
                 return fieldName;
             }
         }

--- a/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
+++ b/src/main/java/io/gsonfire/postprocessors/ExclusionByValuePostProcessor.java
@@ -97,6 +97,7 @@ public final class ExclusionByValuePostProcessor implements PostProcessor {
             }
         }
 
+        this.fieldNameCache.put(field, null);
         return null;
     }
 

--- a/src/main/java/io/gsonfire/postprocessors/MergeMapPostProcessor.java
+++ b/src/main/java/io/gsonfire/postprocessors/MergeMapPostProcessor.java
@@ -2,7 +2,7 @@ package io.gsonfire.postprocessors;
 
 import io.gsonfire.PostProcessor;
 import io.gsonfire.annotations.MergeMap;
-import io.gsonfire.gson.FieldInspector;
+import io.gsonfire.util.FieldInspector;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;

--- a/src/main/java/io/gsonfire/util/FieldInspector.java
+++ b/src/main/java/io/gsonfire/util/FieldInspector.java
@@ -1,4 +1,4 @@
-package io.gsonfire.gson;
+package io.gsonfire.util;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @autor: julio
  */
 public final class FieldInspector {
-    private static final Map<Class, Map<Class<? extends Annotation>, Field[]>> cache = new ConcurrentHashMap<Class, Map<Class<? extends Annotation>, Field[]>>();
+    private final Map<Class, Map<Class<? extends Annotation>, Field[]>> cache = new ConcurrentHashMap<Class, Map<Class<? extends Annotation>, Field[]>>();
 
     public Field[] getAnnotatedFields(Class clazz, Class<? extends Annotation> annotation){
         Field[] fields = getFromCache(clazz, annotation);

--- a/src/test/java/io/gsonfire/gson/ExcludeByValueTest.java
+++ b/src/test/java/io/gsonfire/gson/ExcludeByValueTest.java
@@ -1,0 +1,85 @@
+package io.gsonfire.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.Expose;
+import io.gsonfire.GsonFireBuilder;
+import io.gsonfire.annotations.ExcludeByValue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @autor: joao
+ */
+public class ExcludeByValueTest {
+
+    @Test
+    public void testNonExclusion(){
+        GsonFireBuilder builder = new GsonFireBuilder()
+                .enableExclusionByValue();
+
+        Gson gson = builder.createGson();
+
+        A a = new A();
+        a.a = "a";
+        a.b = new B();
+        a.b.str = "str";
+
+        JsonObject obj = gson.toJsonTree(a).getAsJsonObject();
+
+        assertEquals(obj.get("a").getAsString(), "a");
+        assertEquals(obj.get("b").getAsJsonObject().get("str").getAsString(), "str");
+    }
+
+    @Test
+    public void testExclusion(){
+        GsonFireBuilder builder = new GsonFireBuilder()
+                .enableExclusionByValue();
+
+        Gson gson = builder.createGson();
+
+        A a = new A();
+        a.a = "";
+        a.b = new B();
+        a.b.str = "";
+
+        JsonObject obj = gson.toJsonTree(a).getAsJsonObject();
+
+        assertFalse(obj.has("a"));
+        assertTrue(obj.has("b"));
+        assertFalse(obj.get("b").getAsJsonObject().has("str"));
+    }
+
+
+    private class A {
+
+        @Expose
+        @ExcludeByValue(ExcludeEmptyStringsStrategy.class)
+        public String a;
+
+        @Expose
+        public B b;
+
+    }
+
+    private class B {
+
+        @Expose
+        @ExcludeByValue(ExcludeEmptyStringsStrategy.class)
+        public String str;
+
+    }
+
+    public static class ExcludeEmptyStringsStrategy implements ExclusionByValueStrategy<String> {
+
+        @Override
+        public boolean shouldSkipField(String fieldValue) {
+            return "".equals(fieldValue);
+        }
+
+    }
+
+}

--- a/src/test/java/io/gsonfire/gson/ExcludeByValueTest.java
+++ b/src/test/java/io/gsonfire/gson/ExcludeByValueTest.java
@@ -1,5 +1,6 @@
 package io.gsonfire.gson;
 
+import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.Expose;
@@ -7,9 +8,9 @@ import io.gsonfire.GsonFireBuilder;
 import io.gsonfire.annotations.ExcludeByValue;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.*;
 
 /**
  * @autor: joao
@@ -35,22 +36,29 @@ public class ExcludeByValueTest {
     }
 
     @Test
-    public void testExclusion(){
-        GsonFireBuilder builder = new GsonFireBuilder()
+    public void testExclusion() throws NoSuchFieldException {
+        for(FieldNamingPolicy fieldNamingPolicy: FieldNamingPolicy.values()) {
+            GsonFireBuilder builder = new GsonFireBuilder()
                 .enableExclusionByValue();
 
-        Gson gson = builder.createGson();
+            Gson gson = builder.createGsonBuilder()
+                .setFieldNamingPolicy(fieldNamingPolicy)
+                .create();
 
-        A a = new A();
-        a.a = "";
-        a.b = new B();
-        a.b.str = "";
+            A a = new A();
+            a.a = "";
+            a.b = new B();
+            a.b.str = "";
 
-        JsonObject obj = gson.toJsonTree(a).getAsJsonObject();
+            JsonObject obj = gson.toJsonTree(a).getAsJsonObject();
 
-        assertFalse(obj.has("a"));
-        assertTrue(obj.has("b"));
-        assertFalse(obj.get("b").getAsJsonObject().has("str"));
+            Field fa = A.class.getField("a");
+            Field fb = A.class.getField("b");
+
+            assertFalse(obj.has(fieldNamingPolicy.translateName(fa)));
+            assertTrue(obj.has(fieldNamingPolicy.translateName(fb)));
+            assertFalse(obj.get(fieldNamingPolicy.translateName(fb)).getAsJsonObject().has("str"));
+        }
     }
 
 


### PR DESCRIPTION
This PR allows to remove attributes from the serialized JSON, based on the evaluation of a strategy defined with an attribute annotation.

~~Limitation:~~
~~- since we cannot get the FieldNamingStrategy from GSON, this is only compatible with the IDENTITY naming strategy.~~
Now all the ```FieldNamingStrategy``` are supported. This is made using a (cached) brute force approach that consists in trying every strategy until we find one.