### PR TITLE
Fix NullPointerException on the ExcludeByValueTypeAdapter

### DIFF
--- a/src/main/java/io/gsonfire/gson/ExcludeByValueTypeAdapterFactory.java
+++ b/src/main/java/io/gsonfire/gson/ExcludeByValueTypeAdapterFactory.java
@@ -45,45 +45,50 @@ public final class ExcludeByValueTypeAdapterFactory implements TypeAdapterFactor
 
         @Override
         public void write(JsonWriter out, Object src) throws IOException {
-            JsonObject postProcessedObject = null; //if we detect there is something we should exclude, this will be !=null
-
-            for(Field f: fieldInspector.getAnnotatedMembers(src.getClass(), ExcludeByValue.class)){
-                try {
-                    ExcludeByValue excludeByValue = f.getAnnotation(ExcludeByValue.class);
-                    Class<? extends ExclusionByValueStrategy> exclusionByValueStrategyClass = excludeByValue.value();
-
-                    ExclusionByValueStrategy strategy = exclusionByValueStrategyClass.newInstance();
-                    if (strategy.shouldSkipField(f.get(src))) {
-                        String fieldName = fieldNameResolver.getFieldName(f);
-                        if (fieldName != null) {
-                            //Here we know there is a field we should exclude
-                            //Now let's check if the JsonObject is in memory, if not we will get it
-                            //from the originalTypeAdapter
-                            if(postProcessedObject == null) {
-                                JsonElement originalResult = originalTypeAdapter.toJsonTree(src);
-                                if(originalResult == null || originalResult.isJsonNull() || !originalResult.isJsonObject()) {
-                                    break;
-                                }
-                                postProcessedObject = originalTypeAdapter.toJsonTree(src).getAsJsonObject();
-                            }
-
-                            //Remove the excluded field
-                            postProcessedObject.remove(fieldName);
-                        }
-                    }
-                } catch (IllegalAccessException e) {
-                    throw new RuntimeException(e);
-                } catch (InstantiationException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            if(postProcessedObject != null) {
-                //postProcessedObject is not null, this means that we in fact excluded some fields, we need to rewrite it
-                gson.toJson(postProcessedObject, out);
-            } else {
-                //postProcessedObject was null, this means nothing was excluded, we will just use the original type adapter
+            if (src == null) {
+                //if src is null there is nothing for this type adapter to do, delegate it to the original type adapter
                 originalTypeAdapter.write(out, src);
+            } else {
+                JsonObject postProcessedObject = null; //if we detect there is something we should exclude, this will be !=null
+
+                for(Field f: fieldInspector.getAnnotatedMembers(src.getClass(), ExcludeByValue.class)){
+                    try {
+                        ExcludeByValue excludeByValue = f.getAnnotation(ExcludeByValue.class);
+                        Class<? extends ExclusionByValueStrategy> exclusionByValueStrategyClass = excludeByValue.value();
+
+                        ExclusionByValueStrategy strategy = exclusionByValueStrategyClass.newInstance();
+                        if (strategy.shouldSkipField(f.get(src))) {
+                            String fieldName = fieldNameResolver.getFieldName(f);
+                            if (fieldName != null) {
+                                //Here we know there is a field we should exclude
+                                //Now let's check if the JsonObject is in memory, if not we will get it
+                                //from the originalTypeAdapter
+                                if(postProcessedObject == null) {
+                                    JsonElement originalResult = originalTypeAdapter.toJsonTree(src);
+                                    if(originalResult == null || originalResult.isJsonNull() || !originalResult.isJsonObject()) {
+                                        break;
+                                    }
+                                    postProcessedObject = originalTypeAdapter.toJsonTree(src).getAsJsonObject();
+                                }
+
+                                //Remove the excluded field
+                                postProcessedObject.remove(fieldName);
+                            }
+                        }
+                    } catch (IllegalAccessException e) {
+                        throw new RuntimeException(e);
+                    } catch (InstantiationException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                if(postProcessedObject != null) {
+                    //postProcessedObject is not null, this means that we in fact excluded some fields, we need to rewrite it
+                    gson.toJson(postProcessedObject, out);
+                } else {
+                    //postProcessedObject was null, this means nothing was excluded, we will just use the original type adapter
+                    originalTypeAdapter.write(out, src);
+                }
             }
         }
 


### PR DESCRIPTION
If the object that gets to the ExcludeByValueTypeAdapter is null, there is nothing for this type adapter to do, delegate the call to the original type adapter.