### PR TITLE
Makes the wrap type adapter factory single class

### DIFF
--- a/src/main/java/io/gsonfire/GsonFireBuilder.java
+++ b/src/main/java/io/gsonfire/GsonFireBuilder.java
@@ -230,7 +230,10 @@ public final class GsonFireBuilder {
         }
 
         builder.registerTypeAdapterFactory(new SimpleIterableTypeAdapterFactory());
-        builder.registerTypeAdapterFactory(new WrapTypeAdapterFactory(wrappedClasses));
+
+        for(Map.Entry<Class, Mapper> wrappedEntries: wrappedClasses.entrySet()) {
+            builder.registerTypeAdapterFactory(new WrapTypeAdapterFactory(wrappedEntries.getKey(), wrappedEntries.getValue()));
+        }
 
         return builder;
     }

--- a/src/main/java/io/gsonfire/gson/WrapTypeAdapterFactory.java
+++ b/src/main/java/io/gsonfire/gson/WrapTypeAdapterFactory.java
@@ -7,43 +7,30 @@ import com.google.gson.stream.JsonWriter;
 import io.gsonfire.util.Mapper;
 
 import java.io.IOException;
-import java.util.Map;
 
 /**
  * Created by asanchez on 19/02/16.
  */
 public class WrapTypeAdapterFactory<T> implements TypeAdapterFactory {
 
-    private final Map<Class<T>, Mapper<T, String>> wrappedClasses;
+    private final Class<T> clazz;
+    private final Mapper<T, String> mapper;
 
-    public WrapTypeAdapterFactory(Map<Class<T>, Mapper<T, String>> wrappedClasses) {
-        this.wrappedClasses = wrappedClasses;
+    public WrapTypeAdapterFactory(Class<T> clazz, Mapper<T, String> mapper) {
+        this.clazz = clazz;
+        this.mapper = mapper;
     }
 
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-        final TypeAdapter<T> originalTypeAdapter = gson.getDelegateAdapter(this, type);
-        final Mapper<T, String> mapper = (Mapper<T, String>) getMostSpecificMapper(type.getRawType());
-
-        if (mapper == null) {
-            return originalTypeAdapter;
-        } else {
+        if(clazz.isAssignableFrom(type.getRawType())){
+            final TypeAdapter<T> originalTypeAdapter = gson.getDelegateAdapter(this, type);
             return new NullableTypeAdapter<T>(new WrapperTypeAdapter(mapper, gson, originalTypeAdapter));
+        } else {
+            return null;
         }
     }
 
-    private Mapper<T, String> getMostSpecificMapper(Class clazz) {
-        Mapper<T, String> mostSpecificMapper = null;
-        Class mostSpecificClass = clazz;
-        while (mostSpecificClass != null) {
-            mostSpecificMapper = wrappedClasses.get(mostSpecificClass);
-            if (mostSpecificMapper != null) {
-                return mostSpecificMapper;
-            }
-            mostSpecificClass = mostSpecificClass.getSuperclass();
-        }
-        return null;
-    }
 
     private class WrapperTypeAdapter<T> extends TypeAdapter<T> {
 


### PR DESCRIPTION
@andressanchez please review this change to your pull request #27 

I think it makes it more natural to the Gson standards and we dont need to do the loop to get the parent classes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/julman99/gson-fire/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
