### PR TITLE
Add tests and change parser to allow .2 in addition to .200

### DIFF
--- a/src/main/java/io/gsonfire/util/RFC3339DateFormat.java
+++ b/src/main/java/io/gsonfire/util/RFC3339DateFormat.java
@@ -95,12 +95,12 @@ public final class RFC3339DateFormat extends DateFormat {
             String millisStr = matcher.replaceAll("$2");
             int millisSize = millisStr.length();
 
-            long timeToMultiply = 1;
+            millis = Long.parseLong(millisStr);
+
             if (millisSize - 3 < 0) {
-                timeToMultiply = (long) Math.pow(10, 3 - millisSize);
+                millis = (long) (millis * Math.pow(10, 3 - millisSize));
             }
 
-            millis = Long.parseLong(millisStr) * timeToMultiply;
             source = matcher.replaceAll("$1") + matcher.replaceAll("$4");
         }
 

--- a/src/main/java/io/gsonfire/util/RFC3339DateFormat.java
+++ b/src/main/java/io/gsonfire/util/RFC3339DateFormat.java
@@ -67,7 +67,7 @@ public final class RFC3339DateFormat extends DateFormat {
             long millis = time % 1000L;
             if(millis > 0){
                 String fraction = String.format("%03d", millis);
-                formatted.append(".").append(fraction);
+                formatted.append("." + fraction);
             }
 
             //Timezone

--- a/src/main/java/io/gsonfire/util/RFC3339DateFormat.java
+++ b/src/main/java/io/gsonfire/util/RFC3339DateFormat.java
@@ -6,9 +6,6 @@ import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * @autor: julio
- */
 public final class RFC3339DateFormat extends DateFormat {
 
     private static final Pattern TIMEZONE_PATTERN = Pattern.compile("(.*)([+-][0-9][0-9])\\:?([0-9][0-9])$");
@@ -64,9 +61,10 @@ public final class RFC3339DateFormat extends DateFormat {
         if(this.serializeTime) {
             //Add milliseconds
             long time = date.getTime();
-            if (time % 1000L != 0) {
-                String fraction = String.format("%03d", time % 1000L);
-                formatted.append("." + fraction);
+            long millis = time % 1000L;
+            if(millis > 0){
+                String fraction = String.format("%03d", millis);
+                formatted.append(".").append(fraction);
             }
 
             //Timezone
@@ -92,7 +90,14 @@ public final class RFC3339DateFormat extends DateFormat {
         if(source.contains(".")){
             Matcher matcher = MILLISECONDS_PATTERN.matcher(source);
             String millisStr = matcher.replaceAll("$2");
-            millis = Long.parseLong(millisStr);
+            int millisSize = millisStr.length();
+
+            long timeToMultiply = 1;
+            if (millisSize - 3 < 0) {
+                timeToMultiply = (long) Math.pow(10, 3 - millisSize);
+            }
+
+            millis = Long.parseLong(millisStr) * timeToMultiply;
             source = matcher.replaceAll("$1") + matcher.replaceAll("$4");
         }
 

--- a/src/main/java/io/gsonfire/util/RFC3339DateFormat.java
+++ b/src/main/java/io/gsonfire/util/RFC3339DateFormat.java
@@ -6,6 +6,9 @@ import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * @autor: julio
+ */
 public final class RFC3339DateFormat extends DateFormat {
 
     private static final Pattern TIMEZONE_PATTERN = Pattern.compile("(.*)([+-][0-9][0-9])\\:?([0-9][0-9])$");

--- a/src/test/java/io/gsonfire/util/RFC3339DateFormatTest.java
+++ b/src/test/java/io/gsonfire/util/RFC3339DateFormatTest.java
@@ -61,6 +61,72 @@ public class RFC3339DateFormatTest {
     }
 
     @Test
+    public void test2millisFraction() throws ParseException {
+        RFC3339DateFormat format = new RFC3339DateFormat();
+        String original = "2013-02-07T02:29:08.2Z";
+        String expected = "2013-02-07T02:29:08.200Z";
+        Date date = format.parse(original);
+        String formatted = format.format(date);
+        assertEquals(expected, formatted);
+    }
+
+    @Test
+    public void test22millisFraction() throws ParseException {
+        RFC3339DateFormat format = new RFC3339DateFormat();
+        String original = "2013-02-07T02:29:08.22Z";
+        String expected = "2013-02-07T02:29:08.220Z";
+        Date date = format.parse(original);
+        String formatted = format.format(date);
+        assertEquals(expected, formatted);
+    }
+
+    @Test
+    public void test002millisFraction() throws ParseException {
+        RFC3339DateFormat format = new RFC3339DateFormat();
+        String original = "2013-02-07T02:29:08.002Z";
+        Date date = format.parse(original);
+        String formatted = format.format(date);
+        assertEquals(original, formatted);
+    }
+
+    @Test
+    public void test022millisFraction() throws ParseException {
+        RFC3339DateFormat format = new RFC3339DateFormat();
+        String original = "2013-02-07T02:29:08.022Z";
+        Date date = format.parse(original);
+        String formatted = format.format(date);
+        assertEquals(original, formatted);
+    }
+
+    @Test
+    public void test020millisFraction() throws ParseException {
+        RFC3339DateFormat format = new RFC3339DateFormat();
+        String original = "2013-02-07T02:29:08.020Z";
+        Date date = format.parse(original);
+        String formatted = format.format(date);
+        assertEquals(original, formatted);
+    }
+
+    @Test
+    public void test222millisFraction() throws ParseException {
+        RFC3339DateFormat format = new RFC3339DateFormat();
+        String original = "2013-02-07T02:29:08.222Z";
+        Date date = format.parse(original);
+        String formatted = format.format(date);
+        assertEquals(original, formatted);
+    }
+
+    @Test
+    public void test202millisFraction() throws ParseException {
+        RFC3339DateFormat format = new RFC3339DateFormat();
+        String original = "2013-02-07T02:29:08.202Z";
+        Date date = format.parse(original);
+        String formatted = format.format(date);
+        assertEquals(original, formatted);
+    }
+
+
+    @Test
     public void testParseLowerCase() throws ParseException {
         RFC3339DateFormat format = new RFC3339DateFormat();
         Date date = format.parse("2013-02-07t02:29:08.123z");


### PR DESCRIPTION
# Why
The parser allow an input string like "2013-02-07T02:29:08.2Z" but it formats it like "2013-02-07T02:29:08.002Z". 

# What
Change the parser to have the wanted millis values when it's missing the right 0.
I'm adding more tests, for the different position of a 0 and the omission of the ones in the right.

# How to test
To test the fix, run tests "test2millisFraction" and "test22millisFraction"