### PR TITLE
Fix writing fractional seconds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.gsonfire</groupId>
     <artifactId>gson-fire</artifactId>
-    <version>1.8.4</version>
+    <version>1.8.5</version>
 
     <name>Gson on Fire!</name>
     <description>

--- a/src/main/java/io/gsonfire/util/RFC3339DateFormat.java
+++ b/src/main/java/io/gsonfire/util/RFC3339DateFormat.java
@@ -75,12 +75,14 @@ public final class RFC3339DateFormat extends DateFormat {
             //Add milliseconds
             long time = date.getTime();
             long millis = time % 1000L;
-            if (millis > 0) {
-                String fraction = String.format("%03d", millis);
-                
-                if (!threeDigitMillis) {
-                    fraction = fraction.replaceAll("0*$", "");
-                }
+            
+            String fraction = String.format("%03d", millis);
+            
+            if (!threeDigitMillis) {
+                fraction = fraction.replaceAll("0*$", "");
+            }
+            
+            if (!fraction.isEmpty()) {
                 formatted.append("." + fraction);
             }
 

--- a/src/main/java/io/gsonfire/util/RFC3339DateFormat.java
+++ b/src/main/java/io/gsonfire/util/RFC3339DateFormat.java
@@ -7,7 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * @autor: julio
+ * @author julio
  */
 public final class RFC3339DateFormat extends DateFormat {
 
@@ -18,23 +18,33 @@ public final class RFC3339DateFormat extends DateFormat {
     private final SimpleDateFormat rfc3339Parser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
     private final SimpleDateFormat rfc3339Formatter;
     private final boolean serializeTime;
-
-    public RFC3339DateFormat(TimeZone serializationTimezone, boolean serializeTime) {
+    private final boolean threeDigitMillis;
+    
+    public RFC3339DateFormat(TimeZone serializationTimezone, boolean serializeTime, boolean threeDigitMillis) {
         if(serializeTime) {
             this.rfc3339Formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
         } else {
             this.rfc3339Formatter = new SimpleDateFormat("yyyy-MM-dd");
         }
         this.serializeTime = serializeTime;
+        this.threeDigitMillis = threeDigitMillis;
         this.rfc3339Formatter.setTimeZone(serializationTimezone);
+    }
+    
+    public RFC3339DateFormat(TimeZone serializationTimezone, boolean serializeTime) {
+        this(serializationTimezone, serializeTime, false);
     }
 
     public RFC3339DateFormat(TimeZone serializationTimezone) {
-        this(serializationTimezone, true);
+        this(serializationTimezone, true, false);
+    }
+    
+    public RFC3339DateFormat(boolean serializeTime, boolean threeDigitMillis) {
+        this(TimeZone.getTimeZone("UTC"), serializeTime, threeDigitMillis);
     }
 
     public RFC3339DateFormat(boolean serializeTime) {
-        this(TimeZone.getTimeZone("UTC"), serializeTime);
+        this(serializeTime, false);
     }
 
     public RFC3339DateFormat() {
@@ -64,8 +74,13 @@ public final class RFC3339DateFormat extends DateFormat {
         if(this.serializeTime) {
             //Add milliseconds
             long time = date.getTime();
-            if (time % 1000L != 0) {
-                String fraction = Long.toString((time % 1000L));
+            long millis = time % 1000L;
+            if (millis > 0) {
+                String fraction = String.format("%03d", millis);
+                
+                if (!threeDigitMillis) {
+                    fraction = fraction.replaceAll("0*$", "");
+                }
                 formatted.append("." + fraction);
             }
 

--- a/src/test/java/io/gsonfire/util/RFC3339DateFormatTest.java
+++ b/src/test/java/io/gsonfire/util/RFC3339DateFormatTest.java
@@ -9,7 +9,7 @@ import java.util.TimeZone;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @autor: julio
+ * @author julio
  */
 public class RFC3339DateFormatTest {
 
@@ -103,5 +103,46 @@ public class RFC3339DateFormatTest {
         String formatted = format.format(new Date(1360204148123L));
         assertEquals("2013-02-07", formatted);
     }
-
+    
+    @Test
+    public void testParseWithMillisAndLeadingZero() throws ParseException {
+        RFC3339DateFormat format = new RFC3339DateFormat();
+        Date date = format.parse("2020-10-02T09:25:29.073Z");
+        assertEquals(1601630729073L, date.getTime());
+    }
+    
+    @Test
+    public void testFormatWithMillisWithLeadingZero(){
+        RFC3339DateFormat format = new RFC3339DateFormat();
+        String formatted = format.format(new Date(1601630729073L));
+        assertEquals("2020-10-02T09:25:29.073Z", formatted);
+    }
+    
+    @Test
+    public void testParseWithMillisAndTailingZero() throws ParseException {
+        RFC3339DateFormat format = new RFC3339DateFormat();
+        Date date = format.parse("2020-10-02T09:25:29.730Z");
+        assertEquals(1601630729730L, date.getTime());
+    }
+    
+    @Test
+    public void testParseWithMillisAndWithoutTailingZero() throws ParseException {
+        RFC3339DateFormat format = new RFC3339DateFormat();
+        Date date = format.parse("2020-10-02T09:25:29.73Z");
+        assertEquals(1601630729730L, date.getTime());
+    }
+    
+    @Test
+    public void testFormatWithMillisWithInvisibleTailingZero(){
+        RFC3339DateFormat format = new RFC3339DateFormat();
+        String formatted = format.format(new Date(1601630729730L));
+        assertEquals("2020-10-02T09:25:29.73Z", formatted);
+    }
+    
+    @Test
+    public void testFormatWithMillisWithVisibleTailingZero(){
+        RFC3339DateFormat format = new RFC3339DateFormat(true, true);
+        String formatted = format.format(new Date(1601630729730L));
+        assertEquals("2020-10-02T09:25:29.730Z", formatted);
+    }
 }

--- a/src/test/java/io/gsonfire/util/RFC3339DateFormatTest.java
+++ b/src/test/java/io/gsonfire/util/RFC3339DateFormatTest.java
@@ -145,4 +145,18 @@ public class RFC3339DateFormatTest {
         String formatted = format.format(new Date(1601630729730L));
         assertEquals("2020-10-02T09:25:29.730Z", formatted);
     }
+    
+    @Test
+    public void testFormatWithZeroMillisVisible(){
+        RFC3339DateFormat format = new RFC3339DateFormat(true, true);
+        String formatted = format.format(new Date(1601630729000L));
+        assertEquals("2020-10-02T09:25:29.000Z", formatted);
+    }
+    
+    @Test
+    public void testFormatWithZeroMillisNotVisible(){
+        RFC3339DateFormat format = new RFC3339DateFormat(true, false);
+        String formatted = format.format(new Date(1601630729000L));
+        assertEquals("2020-10-02T09:25:29Z", formatted);
+    }
 }


### PR DESCRIPTION
# What 
Fractional seconds with leading zeros are parsed correctly but written back incorrectly, eg ".073" -> ".73"

This test fails in master branch:
```
@Test
public void testFormatWithMillisWithLeadingZero(){
    RFC3339DateFormat format = new RFC3339DateFormat();
    String formatted = format.format(new Date(1601630729073L));
    assertEquals("2020-10-02T09:25:29.073Z", formatted);
}
```
with 
```
org.junit.ComparisonFailure: 
Expected :2020-10-02T09:25:29.073Z
Actual   :2020-10-02T09:25:29.73Z
```

Also included is a change to allow the user to choose if they always want to see 3 digits in the fractional seconds part or not, eg ".730" vs ".73", basically by not removing trailing zeros. The default is set to remove trailing zeros, thus keeping the original writing behaviour.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/julman99/gson-fire/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
