### PR TITLE
Remove uses of internal gson classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/io/gsonfire/gson/HooksTypeAdapter.java
+++ b/src/main/java/io/gsonfire/gson/HooksTypeAdapter.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.TypeAdapter;
-import com.google.gson.internal.bind.JsonTreeReader;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import io.gsonfire.ClassConfig;
@@ -51,7 +50,7 @@ public final class HooksTypeAdapter<T> extends TypeAdapter<T> {
         JsonElement json = new JsonParser().parse(in);
 
         runPreDeserialize(json);
-        T result = deserialize(json, in.isLenient());
+        T result = JsonUtils.fromJsonTree(originalTypeAdapter, in, json);
 
         //Run all the post deserializers
         if (classConfig.isHooksEnabled()) {
@@ -78,13 +77,6 @@ public final class HooksTypeAdapter<T> extends TypeAdapter<T> {
         for(PreProcessor<? super T> preProcessor: classConfig.getPreProcessors()){
             preProcessor.preDeserialize(clazz, json, gson);
         }
-    }
-
-    private T deserialize(JsonElement json, boolean lenient) throws IOException{
-        JsonReader jsonReader = new JsonTreeReader(json);
-        jsonReader.setLenient(lenient);
-        T deserialized = originalTypeAdapter.read(jsonReader);
-        return deserialized;
     }
 
 }

--- a/src/main/java/io/gsonfire/util/JsonUtils.java
+++ b/src/main/java/io/gsonfire/util/JsonUtils.java
@@ -50,10 +50,10 @@ public class JsonUtils {
                 null,
                 new Configurable<JsonWriter>() {
                     @Override
-                    public void configure(JsonWriter jsonReader) {
-                        jsonReader.setLenient(optionsFrom.isLenient());
-                        jsonReader.setHtmlSafe(optionsFrom.isHtmlSafe());
-                        jsonReader.setSerializeNulls(optionsFrom.getSerializeNulls());
+                    public void configure(JsonWriter jsonWriter) {
+                        jsonWriter.setLenient(optionsFrom.isLenient());
+                        jsonWriter.setHtmlSafe(optionsFrom.isHtmlSafe());
+                        jsonWriter.setSerializeNulls(optionsFrom.getSerializeNulls());
                     }
                 }
         ).toJsonTree(value);

--- a/src/main/java/io/gsonfire/util/JsonUtils.java
+++ b/src/main/java/io/gsonfire/util/JsonUtils.java
@@ -78,7 +78,7 @@ public class JsonUtils {
         private final Configurable<JsonWriter> jsonWriterConfigurable;
 
         public ConfigurableTypeAdapter(TypeAdapter<T> originalTypeAdapter, Configurable<JsonReader> jsonReaderConfigurable, Configurable<JsonWriter> jsonWriterConfigurable) {
-            this. originalTypeAdapter= originalTypeAdapter;
+            this.originalTypeAdapter= originalTypeAdapter;
             this.jsonReaderConfigurable = jsonReaderConfigurable;
             this.jsonWriterConfigurable = jsonWriterConfigurable;
         }


### PR DESCRIPTION
Replaces uses of internal `com.google.gson.internal.bind.*` classes from gson-fire and replaces them with an alternative way of configuring the json reader and writer classes.

Fixes https://github.com/julman99/gson-fire/issues/52